### PR TITLE
Skip null ranked data

### DIFF
--- a/opgg/opgg.py
+++ b/opgg/opgg.py
@@ -243,6 +243,8 @@ class OPGG:
                 
                 tmp_rank_entries = []
                 for rank_entry in season["rank_entries"]:
+                    if rank_entry["rank_info"] is None:
+                        continue
                     tmp_rank_entries.append(RankEntry(
                         game_type = rank_entry["game_type"],
                         rank_info = Tier(


### PR DESCRIPTION
This issue occurs when someone has a rank for one ranked type but not the other (for example, I was ranked in solo/duo for a split, but didn't play flex), and so the dictionary has no values to extract. This error prevents the rest of the data being collected for the summoner.